### PR TITLE
Upstream fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+.idea/

--- a/sm.py
+++ b/sm.py
@@ -32,21 +32,20 @@ async def handle_sponsor_webhook(
     log.info(f"Sponsorship update: {data.action}")
 
     user = data.sponsorship["sponsor"]["login"]
-    user_id = data.sponsorship["sponsor"]["id"]
-    tier = int(data.sponsorship["tier"]["monthly_price_in_dollars"])
+    tier = int(float(data.sponsorship["tier"]["monthly_price_in_dollars"]))
 
     if data.action == SponsorAction.CREATED:
-        await github.send_org_invite(user_id, tier)
+        await github.send_org_invite(user, tier)
 
     elif data.action == SponsorAction.CANCELLED:
         await github.remove_user_from_org(user)
 
     elif data.action == SponsorAction.PENDING_TIER_CHANGE:
-        from_tier = data.changes["tier"]["from"]["monthly_price_in_dollars"]
+        from_tier = int(float(data.changes["tier"]["from"]["monthly_price_in_dollars"]))
 
         if tier < settings.minimum_tier:
             await github.remove_user_from_org(user)
-        elif tier >= settings.minimum_tier and from_tier < settings.minimum_tier:
-            await github.send_org_invite(user_id, tier)
+        elif tier >= settings.minimum_tier > from_tier:
+            await github.send_org_invite(user, tier)
 
     return Response(status_code=status.HTTP_200_OK)

--- a/sponsormonitor/config.py
+++ b/sponsormonitor/config.py
@@ -20,5 +20,5 @@ def get_settings():
     return Settings(
         github_org=config["Default"]["OrgName"],
         minimum_tier=config["Default"]["MinTier"],
-        tiers={int(k): v for k, v in config["Tiers"].items()},
+        tiers={k: v for k, v in config["Tiers"].items()},
     )

--- a/sponsormonitor/config.py
+++ b/sponsormonitor/config.py
@@ -20,5 +20,5 @@ def get_settings():
     return Settings(
         github_org=config["Default"]["OrgName"],
         minimum_tier=config["Default"]["MinTier"],
-        tiers={k: v for k, v in config["Tiers"].items()},
+        tiers={int(k): v for k, v in config["Tiers"].items()},
     )

--- a/sponsormonitor/github.py
+++ b/sponsormonitor/github.py
@@ -10,7 +10,7 @@ log = logging.getLogger("sponsormonitor.github")
 settings = config.get_settings()
 
 
-# https://developer.github.com/v3/teams/#list-teams
+# https://docs.github.com/en/rest/reference/teams#list-teams
 async def get_team_slug(team_name):
     async with httpx.AsyncClient() as client:
         r = await client.get(
@@ -50,7 +50,7 @@ async def send_org_invite(user: str, tier: int):
             raise Exception(f"Unexpected status code returned {r.status_code}: {r.text}")
 
 
-# https://developer.github.com/v3/orgs/members/#remove-organization-membership-for-a-user
+# https://docs.github.com/en/rest/reference/orgs#remove-an-organization-member
 async def remove_user_from_org(user):
     async with httpx.AsyncClient() as client:
         r = await client.delete(

--- a/sponsormonitor/github.py
+++ b/sponsormonitor/github.py
@@ -30,7 +30,7 @@ async def get_team_slug(team_name):
 
 
 # https://docs.github.com/en/rest/reference/teams#add-or-update-team-membership-for-a-user
-async def send_org_invite(user_id: int, tier: int):
+async def send_org_invite(user: str, tier: int):
     team_name = settings.tiers.get(tier)
     if not team_name:
         raise Exception(
@@ -41,7 +41,7 @@ async def send_org_invite(user_id: int, tier: int):
 
     async with httpx.AsyncClient() as client:
         r = await client.put(
-            f"https://api.github.com/orgs/{settings.github_org}/teams/{team_slug}/memberships/{user_id}",
+            f"https://api.github.com/orgs/{settings.github_org}/teams/{team_slug}/memberships/{user}",
             headers={"Authorization": f"token {settings.github_access_token}"},
             json={"role": "member"},
         )


### PR DESCRIPTION
1. I have gotten `monthly_price_in_dollars` as a string like `"15.0"`, even thought the [GitHub docs](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#webhook-payload-example-when-someone-downgrades-a-sponsorship) show it as a number. `int(float())` fixes this problem for both cases since it will cast `15, '15', 15.0, '15.0'` all to the correct value.
2. I replaced the org invite with the teams endpoint. There was an issue where if someone changed tiers, the re-invitation would fail because they already belong in the org. The teams endpoint will handle adding them to the correct team while still sending the org invite if needed. This also required me to use team slugs instead of id, and the user name instead of id.
3. The "remove user" endpoint returns a 204, not a 200.

